### PR TITLE
Added interpolation that is compatible with python 3.

### DIFF
--- a/src/ca/szc/configparser/exceptions/InterpolationDepthError.java
+++ b/src/ca/szc/configparser/exceptions/InterpolationDepthError.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.szc.configparser.exceptions;
+
+/**
+ * This exception is thrown if a value has to be interpolated too many times.
+ */
+public class InterpolationDepthError extends ParsingError
+{
+    private String section;
+    private String option;
+    private String value;
+
+    public InterpolationDepthError(int lineNo, String option, String section, String value)
+    {
+        super(lineNo);
+        this.option = option;
+        this.section = section;
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        InterpolationDepthError other = (InterpolationDepthError) obj;
+
+        return (section == null ? other.section == null : section.equals (other.section)) &&
+               (option == null ? other.option == null : option.equals (other.option)) &&
+               (value == null ? other.value == null : value.equals (other.value));
+    }
+
+    @Override
+    public String getMessage()
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("Interpolation depth exceeded processing '");
+        sb.append(getValue());
+        sb.append("' for option '");
+        sb.append(getOptionName());
+        sb.append("' in section '");
+        sb.append(getSectionName());
+        sb.append("'");
+
+        return sb.toString();
+    }
+
+    public String getOptionName ()
+    {
+        return option;
+    }
+
+    public String getSectionName ()
+    {
+        return section;
+    }
+
+    public String getValue ()
+    {
+        return value;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((option == null) ? 0 : option.hashCode());
+        result = prime * result + ((section == null) ? 0 : section.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+
+        return result;
+    }
+}

--- a/src/ca/szc/configparser/exceptions/InterpolationMissingOptionError.java
+++ b/src/ca/szc/configparser/exceptions/InterpolationMissingOptionError.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.szc.configparser.exceptions;
+
+/**
+ * This exception is thrown if the interpolation references a non-existent option.
+ */
+public class InterpolationMissingOptionError extends ParsingError
+{
+    private String option;
+    private String section;
+    private String value;
+    private String missingOption;
+
+    public InterpolationMissingOptionError (int lineNo, String option, String section, String value, String missingOption)
+    {
+        super(lineNo);
+        this.option = option;
+        this.section = section;
+        this.value = value;
+        this.missingOption = missingOption;
+    }
+
+    @Override
+    public boolean equals (Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        InterpolationMissingOptionError other = (InterpolationMissingOptionError) obj;
+
+        return (section == null ? other.section == null : section.equals(other.section)) &&
+               (option == null ? other.option == null : option.equals(other.option)) &&
+               (value == null ? other.value == null : value.equals(other.value)) &&
+               (missingOption == null ? other.missingOption == null : missingOption.equals (other.missingOption));
+    }
+
+    @Override
+    public String getMessage()
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("Interpolation error in section '");
+        sb.append(getSectionName ());
+        sb.append("', option '");
+        sb.append(getOptionName ());
+        sb.append("': '");
+        sb.append(getValue ());
+        sb.append("' is missing option '");
+        sb.append(getMissingOption ());
+        sb.append("'");
+
+        return sb.toString();
+    }
+
+    public String getOptionName()
+    {
+        return option;
+    }
+
+    public String getSectionName()
+    {
+        return section;
+    }
+
+    public String getValue ()
+    {
+        return value;
+    }
+
+    public String getMissingOption ()
+    {
+        return missingOption;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((option == null) ? 0 : option.hashCode());
+        result = prime * result + ((section == null) ? 0 : section.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        result = prime * result + ((missingOption == null) ? 0 : missingOption.hashCode());
+
+        return result;
+    }
+}

--- a/src/ca/szc/configparser/exceptions/InterpolationSyntaxError.java
+++ b/src/ca/szc/configparser/exceptions/InterpolationSyntaxError.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.szc.configparser.exceptions;
+
+/**
+ * This exception is thrown if there is a syntax error in the value interpolation.
+ */
+public class InterpolationSyntaxError extends ParsingError
+{
+    private String option;
+    private String section;
+    private String message;
+
+    public InterpolationSyntaxError (int lineNo, String option, String section, String message)
+    {
+        super(lineNo);
+        this.option = option;
+        this.section = section;
+        this.message = message;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        InterpolationSyntaxError other = (InterpolationSyntaxError) obj;
+
+        return (section == null ? other.section == null : section.equals(other.section)) &&
+               (option == null ? other.option == null : option.equals(other.option)) &&
+               (message == null ? other.message == null : message.equals(other.message));
+    }
+
+    @Override
+    public String getMessage()
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("Interpolation syntax error in section '");
+        sb.append(getSectionName ());
+        sb.append("', option '");
+        sb.append(getOptionName ());
+        sb.append("': ");
+        sb.append(message);
+
+        return sb.toString();
+    }
+
+    public String getOptionName()
+    {
+        return option;
+    }
+
+    public String getSectionName()
+    {
+        return section;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((option == null) ? 0 : option.hashCode());
+        result = prime * result + ((section == null) ? 0 : section.hashCode());
+        result = prime * result + ((message == null) ? 0 : message.hashCode());
+
+        return result;
+    }
+}

--- a/src/ca/szc/configparser/exceptions/NoOptionError.java
+++ b/src/ca/szc/configparser/exceptions/NoOptionError.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.szc.configparser.exceptions;
+
+/**
+ * This exception is thrown when looking up a non-existant option from an interpolation.
+ */
+public class NoOptionError extends Exception
+{
+    private String section;
+    private String option;
+
+    public NoOptionError (String section, String option)
+    {
+        super("No option exists with name '" + option + "' in section '" + section + "'");
+        this.section = section;
+        this.option = option;
+    }
+
+    public String getSectionName()
+    {
+        return section;
+    }
+
+    public String getOption()
+    {
+        return option;
+    }
+}

--- a/src/ca/szc/configparser/exceptions/NoSectionError.java
+++ b/src/ca/szc/configparser/exceptions/NoSectionError.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.szc.configparser.exceptions;
+
+/**
+ * This exception is thrown when looking up a non-existant section from an interpolation.
+ */
+public class NoSectionError extends Exception
+{
+    private String section;
+
+    public NoSectionError (String section)
+    {
+        super("No section exists with name '" + section + "'");
+        this.section = section;
+    }
+
+    public String getSectionName()
+    {
+        return section;
+    }
+
+}

--- a/test/resources/interpolation-errors.cfg
+++ b/test/resources/interpolation-errors.cfg
@@ -1,0 +1,6 @@
+[interpolation fail]
+case1 = ${where's the brace
+case2 = ${does_not_exist}
+case3 = ${wrong_section:wrong_value}
+case4 = ${i:like:colon:characters}
+case5 = $100 for Fail No 5!

--- a/test/resources/interpolation.cfg
+++ b/test/resources/interpolation.cfg
@@ -1,0 +1,21 @@
+[common]
+favourite Beatle = Paul
+favourite color = green
+
+[tom]
+favourite band = ${common:favourite color} day
+favourite pope = John ${common:favourite Beatle} II
+sequel = ${favourite pope}I
+
+[ambv]
+favourite Beatle = George
+son of Edward VII = ${favourite Beatle} V
+son of George V = ${son of Edward VII}I
+
+[stanley]
+favourite Beatle = ${ambv:favourite Beatle}
+favourite pope = ${tom:favourite pope}
+favourite color = black
+favourite state of mind = paranoid
+favourite movie = soylent ${common:favourite color}
+favourite song = ${favourite color} sabbath - ${favourite state of mind}


### PR DESCRIPTION
This PR introduces value interpolation of the form ${option} or ${section:option}. Interpolation is performed at the end of the read method so that the sections map contains the interpolated values. Errors are raised if interpolations cannot be parsed.

The original values are kept in the rawValues map so that they can written back out again. 

Interpolation is enabled by default, but can be disabled with the setAllowInterpolation method.

Tests have been added to check for valid interpolations, detect and handle error conditions and write out unaltered interpolations.
