### PR TITLE
If inline comments are allowed and in actual line have no comment, an exception occurs

### DIFF
--- a/src/ca/szc/configparser/Ini.java
+++ b/src/ca/szc/configparser/Ini.java
@@ -422,7 +422,7 @@ public class Ini
             // whitespace character before it
             if (inlineCommentPrefixes.size() > 0)
             {
-                int earliestIndex = Integer.MAX_VALUE;
+                int earliestIndex = line.length();
                 for (String prefix : inlineCommentPrefixes)
                 {
                     int index = line.indexOf(prefix);


### PR DESCRIPTION
Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: 2147483647
	at java.lang.String.substring(String.java:1963)
	at ca.szc.configparser.Ini.read(Ini.java:456)
	at ca.szc.configparser.Ini.read(Ini.java:663)
	at ca.szc.configparser.Ini.read(Ini.java:641)